### PR TITLE
refactor(options): use system font stack

### DIFF
--- a/src/options/styles.css
+++ b/src/options/styles.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
 :root {
   --bg-primary: #ffffff;
   --bg-secondary: #f8f9fb;
@@ -28,7 +26,7 @@
 }
 
 body {
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   font-size: 15px;
   line-height: 1.6;
   color: var(--text-primary);


### PR DESCRIPTION
Removes external request to fonts.googleapis.com because there are [many privacy concerns] with it, and eliminating them all by just specifying a local font stack is fine, in my opinion. What do you think?

[many privacy concerns]: https://github.com/google/fonts/issues/1495